### PR TITLE
修正檔案下載失敗的問題

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,5 +1,5 @@
 require "google/cloud/storage"
-
+require 'open-uri'
 class AttachmentsController < ApplicationController
   before_action :find_member, only: %i[new create download]
 
@@ -31,7 +31,8 @@ class AttachmentsController < ApplicationController
     attachment = @member.attachments.find(params[:id])
     bucket = find_bucket
     file = bucket.file(attachment.storage_path)
-    send_data(file, filename: attachment.file_name)
+    file_data = open(file.signed_url).read
+    send_data(file_data, filename: attachment.file_name)
   end
 
   private


### PR DESCRIPTION
### Summary
圖片下載後無法打開

### Details
1. 使用 open-uri 套件
2. 將遠端檔案連結打開，再用 read 取得 data，再用 send_data 下載

